### PR TITLE
Issue mhmerrill#734:  Create Registration List Function

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -8,7 +8,7 @@ from arkouda.logger import getArkoudaLogger
 from arkouda.message import RequestMessage, MessageFormat, ReplyMessage, \
      MessageType
 
-__all__ = ["AllSymbols", "connect", "disconnect", "shutdown", "get_config", 
+__all__ = ["AllSymbols", "RegisteredSymbols", "connect", "disconnect", "shutdown", "get_config",
            "get_mem_used", "__version__", "ruok"]
 
 # Try to read the version from the file located at ../VERSION
@@ -40,6 +40,7 @@ pdarrayIterThresh  = pdarrayIterThreshDefVal
 maxTransferBytesDefVal = 2**30
 maxTransferBytes = maxTransferBytesDefVal
 AllSymbols = "__AllSymbols__"
+RegisteredSymbols = "__RegisteredSymbols__"
 
 logger = getArkoudaLogger(name='Arkouda Client') 
 clientLogger = getArkoudaLogger(name='Arkouda User Logger', logFormat='%(message)s')   

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -320,19 +320,36 @@ module MultiTypeSymbolTable
         */
         proc info(name:string): string throws {
             var s: string;
-            if name == "__AllSymbols__" {
+            if tab.size == 0 {
+                s = "the symbol table is empty";
+            }
+            else if name == "__AllSymbols__" {
                 for n in tab {
-                    s += "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t\n".format(n, 
+                    s += "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t registered:%t\n".format(n, 
                               dtype2str(tab.getBorrowed(n).dtype), tab.getBorrowed(n).size, 
                               tab.getBorrowed(n).ndim, tab.getBorrowed(n).shape, 
-                              tab.getBorrowed(n).itemsize);
+                              tab.getBorrowed(n).itemsize, registry.contains(n));
                 }
-            } else {
+            } 
+            else if name == "__RegisteredSymbols__" {
+                if registry.size == 0 {
+                    s = "the registry is empty";
+                }
+                else {
+                    for n in registry {
+                        s += "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t registered:%t\n".format(n, 
+                                  dtype2str(tab.getBorrowed(n).dtype), tab.getBorrowed(n).size, 
+                                  tab.getBorrowed(n).ndim, tab.getBorrowed(n).shape, 
+                                  tab.getBorrowed(n).itemsize, registry.contains(n));
+                    }
+                }
+            }
+            else {
                 if (tab.contains(name)) {
-                    s = "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t\n".format(name, 
+                    s = "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t registered:%t\n".format(name, 
                               dtype2str(tab.getBorrowed(name).dtype), tab.getBorrowed(name).size, 
                               tab.getBorrowed(name).ndim, tab.getBorrowed(name).shape, 
-                              tab.getBorrowed(name).itemsize);
+                              tab.getBorrowed(name).itemsize, registry.contains(name));
                 }
                 else {
                     throw getErrorWithContext(


### PR DESCRIPTION
This pull request (Issue #734) adds functionality to list all objects in the registry

- Adds `registered` field to the output of `ak.info()`
- Adds special `__RegisteredSymbols__` symbol which prints all registered objects when passed to `ak.info`  (`ak.info(ak.RegisteredSymbols)`).  This behaves similarly to the `__AllSymbols__` symbol
- Adds checks to return a message when info is called with an empty symbol table or `RegisteredSymbols` is used with an empty registry
- Updates `registration_test.py` to test new info() functionality

Change in behavior:  A `registered` field has been added to `ak.info()` . This may effect any logic which relies on the number or order of fields returned by `ak.info()`

I've marked this as a draft because I'm unsure if `test_register_info` should be broken up into two or more tests